### PR TITLE
Remove tweet button scoring and explain chaos energy

### DIFF
--- a/assets/game.js
+++ b/assets/game.js
@@ -463,7 +463,7 @@ class PresidentGame {
         // Apply game effects
         this.chaos = Math.min(100, this.chaos + analysis.chaos);
         this.energy -= analysis.energyCost;
-        this.score += analysis.score;
+        
 
         input.value = '';
         
@@ -500,7 +500,6 @@ class PresidentGame {
             powerEffects: {},
             chaos: 5,
             energyCost: 5,
-            score: 10,
             warnings: []
         };
 
@@ -624,9 +623,6 @@ class PresidentGame {
                 analysis.warnings.push('Typo goes viral!');
             }
         });
-
-        // SCORE CALCULATION
-        analysis.score = Math.abs(analysis.chaos) * 5 + Object.values(analysis.powerEffects).reduce((sum, val) => sum + Math.abs(val), 0) * 2;
 
         return analysis;
     }

--- a/assets/styles.css
+++ b/assets/styles.css
@@ -141,6 +141,25 @@ body {
     gap: 15px;
 }
 
+.status-explainer {
+    background: rgba(0, 0, 0, 0.6);
+    border-left: 3px solid #ffd700;
+    padding: 12px 15px;
+    border-radius: 10px;
+    margin-bottom: 20px;
+    font-size: 13px;
+    line-height: 1.5;
+    color: rgba(255, 255, 255, 0.85);
+}
+
+.status-explainer p {
+    margin-bottom: 6px;
+}
+
+.status-explainer p:last-child {
+    margin-bottom: 0;
+}
+
 /* NEWS TICKER - SLOWER SPEED */
 .news-ticker {
     background: linear-gradient(90deg, #8b0000, #ff0000, #8b0000);

--- a/index.html
+++ b/index.html
@@ -28,6 +28,11 @@
             <div>🏆 Score: <span id="score">0</span></div>
         </div>
 
+        <div class="status-explainer">
+            <p><strong>Energy</strong> is your remaining political capital and staff bandwidth. Run out and aggressive responses will be locked until it recovers.</p>
+            <p><strong>Chaos</strong> tracks how unstable the nation feels. High chaos invites wilder crises and rewards but makes control harder.</p>
+        </div>
+
         <!-- REAL-TIME NEWS TICKER -->
         <div class="news-ticker" id="newsTicker">
             <div class="news-ticker-content" id="newsTickerContent">


### PR DESCRIPTION
## Summary
- remove the client-side score bonus that was previously applied when sending a tweet
- add HUD copy that clarifies what Energy and Chaos measure, including styling for the helper text

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68dd8c795b50832a9848db33aae90e9d