### PR TITLE
Add notification inbox system and public opinion battle mini-game

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,3 +51,73 @@ A real-time political simulation game with live news integration, relationship m
 - CSS3 with animations and responsive design
 - Vercel Serverless Functions for API security
 - NewsAPI and RSS feeds for real-time data
+
+## Notification Inbox & Public Opinion Battle Setup
+
+**Quick Install (3 Steps)**
+
+````
+1) Add CSS
+# Copy everything from notification-inbox-styles.css
+# Paste at END of assets/styles.css
+
+2) Add JavaScript Classes
+// In assets/game.js, BEFORE "class PresidentGame"
+// Add NotificationInbox class
+// Add PublicOpinionBattleGame class
+
+3) Update Constructor & Methods
+// In PresidentGame constructor, add:
+this.inbox = new NotificationInbox(this);
+this.activeBattles = [];
+
+// Replace showNotification() method
+// Replace createPublicOpinionBattle() method
+``` :contentReference[oaicite:5]{index=5}
+````
+
+**Testing the Features** (verbatim, condensed by sections as given):  
+````
+
+Test Notification Inbox
+
+1. Start the game - You should see a gold inbox icon (📫) in the top-right corner
+2. Play normally - Notifications will appear and auto-save to inbox
+3. Click inbox icon - Slide-out panel should appear from the right
+4. Filter notifications - Click filter buttons (All, Info, Success, Warning, Error)
+5. View details - Click any notification to see full popup with timestamp
+6. Check unread badge - Red badge should show number of unread notifications
+7. Refresh page - Notifications should persist (stored in localStorage)
+
+Test Public Opinion Battle Mini-Game
+
+1. Trigger a battle - This happens when opposition politicians respond to your tweets
+2. Watch the intro - Animated entrance with purple gradient background
+3. Choose responses - 5 rounds of strategic choices
+4. Use power-ups - Try Media Spin, Populist Appeal, or Fact Check
+5. Watch timer - 2-minute countdown with pulsing animation
+6. See results - Victory/defeat screen with effects on power centers
+7. Check inbox - Battle results are saved as notifications
+
+``` :contentReference[oaicite:6]{index=6}
+````
+
+**Important Notes** (verbatim):  
+```
+
+Order Matters: Add classes BEFORE PresidentGame
+Constructor: Must initialize inbox in constructor
+Methods: Must replace showNotification & createPublicOpinionBattle
+CSS: Must add ALL styles (don’t skip any)
+
+``` :contentReference[oaicite:7]{index=7}
+
+**Quick Troubleshooting** (verbatim):  
+```
+
+No inbox icon -> Check constructor initialization
+Notifications not saving -> Check browser localStorage
+Battles not appearing -> Add class & replace createPublicOpinionBattle
+Console errors -> Paste CSS, check for conflicts
+
+``` :contentReference[oaicite:8]{index=8}

--- a/assets/game.js
+++ b/assets/game.js
@@ -20,6 +20,562 @@ function startPresidency() {
     game.init();
 }
 
+/*
+==============================================================================
+ENHANCED GAME CODE — Notification Inbox & Public Opinion Battle Mini-Game
+Add these methods and updates to your PresidentGame Class in assets/game.js
+==============================================================================
+*/
+
+// ============= NOTIFICATION INBOX SYSTEM =============
+
+class NotificationInbox {
+  constructor(game) {
+    this.game = game;
+    this.notifications = [];
+    this.unreadCount = 0;
+    this.isOpen = false;
+    this.currentFilter = 'all';
+    this.maxStored = 100;
+
+    this.loadStoredNotifications();
+    this.setupInboxUI();
+  }
+
+  loadStoredNotifications() {
+    try {
+      const stored = localStorage.getItem('notificationInbox');
+      if (stored) {
+        const data = JSON.parse(stored);
+        this.notifications = data.notifications || [];
+        this.unreadCount = data.unreadCount || 0;
+      }
+    } catch (e) {
+      console.warn('failed to load notification inbox:', e);
+    }
+  }
+
+  saveNotifications() {
+    try {
+      localStorage.setItem('notificationInbox', JSON.stringify({
+        notifications: this.notifications.slice(0, this.maxStored),
+        unreadCount: this.unreadCount,
+      }));
+    } catch (e) {
+      console.warn('failed to save notifications:', e);
+    }
+  }
+
+  setupInboxUI() {
+    // Create inbox icon
+    const icon = document.createElement('div');
+    icon.className = 'notification-inbox-icon';
+    icon.innerHTML = `
+      <div class="inbox-icon">📫</div>
+      <div class="inbox-badge" style="display: ${this.unreadCount > 0 ? 'flex' : 'none'}">
+        ${this.unreadCount}
+      </div>
+    `;
+    icon.onclick = () => this.toggleInbox();
+    document.body.appendChild(icon);
+    this.iconElement = icon;
+
+    // Create inbox panel
+    const panel = document.createElement('div');
+    panel.className = 'notification-inbox-panel';
+    panel.innerHTML = `
+      <div class="inbox-header">
+        <h3>Notification Inbox</h3>
+        <button class="inbox-close-btn">×</button>
+      </div>
+      <div class="inbox-filters">
+        <button class="inbox-filter-btn active" data-filter="all">All</button>
+        <button class="inbox-filter-btn" data-filter="info">Info</button>
+        <button class="inbox-filter-btn" data-filter="success">Success</button>
+        <button class="inbox-filter-btn" data-filter="warning">Warning</button>
+        <button class="inbox-filter-btn" data-filter="error">Errors</button>
+      </div>
+      <div id="inboxContent"></div>
+    `;
+    document.body.appendChild(panel);
+    this.panelElement = panel;
+
+    panel.querySelector('.inbox-close-btn').onclick = () => this.closeInbox();
+    panel.querySelectorAll('.inbox-filter-btn').forEach(btn => {
+      btn.onclick = () => this.setFilter(btn.dataset.filter);
+    });
+
+    this.renderInbox();
+  }
+
+  addNotification(message, type = 'info', metadata = {}) {
+    const notification = {
+      id: Date.now() + Math.random(),
+      message: this.game.sanitizeText(message),
+      type,
+      timestamp: Date.now(),
+      read: false,
+      metadata,
+    };
+
+    this.notifications.unshift(notification);
+    this.unreadCount++;
+
+    // Update badge
+    const badge = this.iconElement.querySelector('.inbox-badge');
+    badge.style.display = 'flex';
+    badge.textContent = this.unreadCount;
+
+    // Keep only the latest notifications
+    if (this.notifications.length > this.maxStored) {
+      this.notifications = this.notifications.slice(0, this.maxStored);
+    }
+
+    this.saveNotifications();
+    if (this.isOpen) this.renderInbox();
+
+    return notification.id;
+  }
+
+  toggleInbox() {
+    if (this.isOpen) this.closeInbox();
+    else this.openInbox();
+  }
+
+  openInbox() {
+    this.isOpen = true;
+    this.panelElement.classList.add('open');
+    this.renderInbox();
+  }
+
+  closeInbox() {
+    this.isOpen = false;
+    this.panelElement.classList.remove('open');
+  }
+
+  setFilter(filter) {
+    this.currentFilter = filter;
+
+    // Update active button
+    this.panelElement.querySelectorAll('.inbox-filter-btn').forEach(btn => {
+      btn.classList.toggle('active', btn.dataset.filter === filter);
+    });
+
+    this.renderInbox();
+  }
+
+  renderInbox() {
+    const content = this.panelElement.querySelector('#inboxContent');
+
+    const filtered = this.currentFilter === 'all'
+      ? this.notifications
+      : this.notifications.filter(n => n.type === this.currentFilter);
+
+    if (filtered.length === 0) {
+      content.innerHTML = `
+        <div style="text-align: center; padding: 40px; color: #aaa;">
+          <div style="font-size: 48px; margin-bottom: 15px;">📭</div>
+          <div>${this.currentFilter === 'all' ? 'No notifications' : `No ${this.currentFilter} notifications`}</div>
+        </div>
+      `;
+      return;
+    }
+
+    content.innerHTML = filtered.map(n => {
+      const timeAgo = this.formatTimeAgo(n.timestamp);
+      return `
+        <div class="inbox-notification ${n.type} ${n.read ? '' : 'unread'}" data-id="${n.id}">
+          <div class="inbox-notification-header">
+            <span style="font-weight: 600; text-transform: capitalize;">${n.type}</span>
+            <span class="inbox-notification-time">${timeAgo}</span>
+          </div>
+          <div class="inbox-notification-preview">${n.message}</div>
+        </div>
+      `;
+    }).join('');
+
+    // Add click handlers
+    content.querySelectorAll('.inbox-notification').forEach(el => {
+      el.onclick = () => {
+        const id = parseFloat(el.dataset.id);
+        this.openNotificationDetail(id);
+      };
+    });
+  }
+
+  openNotificationDetail(id) {
+    const notification = this.notifications.find(n => n.id === id);
+    if (!notification) return;
+
+    // Mark as read
+    if (!notification.read) {
+      notification.read = true;
+      this.unreadCount = Math.max(0, this.unreadCount - 1);
+
+      const badge = this.iconElement.querySelector('.inbox-badge');
+      badge.textContent = this.unreadCount;
+      badge.style.display = this.unreadCount > 0 ? 'flex' : 'none';
+    }
+
+    this.saveNotifications();
+    this.renderInbox();
+
+    // Create modal
+    const existing = document.querySelector('.notification-detail-modal');
+    if (existing) existing.remove();
+
+    const modal = document.createElement('div');
+    modal.className = 'notification-detail-modal';
+
+    const icons = {
+      info: 'ℹ️',
+      success: '✅',
+      warning: '⚠️',
+      error: '❌',
+    };
+
+    const timestamp = new Date(notification.timestamp).toLocaleString();
+
+    modal.innerHTML = `
+      <div class="notification-detail-header">
+        <div class="notification-detail-icon">${icons[notification.type] || ''}</div>
+        <div class="notification-detail-title">
+          <h3 style="text-transform: capitalize;">${notification.type} Notifications</h3>
+          <div class="time">${timestamp}</div>
+        </div>
+      </div>
+      <div class="notification-detail-content">
+        ${notification.message}
+        ${notification.metadata && Object.keys(notification.metadata).length ? `
+          <div style="margin-top: 8px; padding: 12px; background: rgba(0,0,0,0.3); border-radius: 10px;">
+            <div style="margin-bottom: 6px;">Additional Details:</div>
+            ${Object.entries(notification.metadata).map(([key, value]) =>
+              `<div style="margin-top: 8px;"><span style="color: var(--primary-gold);">${key}</span>: <span>${value}</span></div>`
+            ).join('')}
+          </div>` : ''
+        }
+      </div>
+      <div class="notification-detail-actions">
+        <button class="close-modal" style="flex: 1;">Close</button>
+      </div>
+    `;
+
+    document.body.appendChild(modal);
+    document.querySelector('.close-modal').onclick = () => modal.remove();
+  }
+
+  formatTimeAgo(timestamp) {
+    const seconds = Math.floor((Date.now() - timestamp) / 1000);
+    if (seconds < 60) return 'just now';
+    if (seconds < 3600) return `${Math.floor(seconds / 60)}m ago`;
+    if (seconds < 86400) return `${Math.floor(seconds / 3600)}h ago`;
+    if (seconds < 604800) return `${Math.floor(seconds / 86400)}d ago`;
+    return new Date(timestamp).toLocaleDateString();
+  }
+
+  clearAll() {
+    if (confirm('Clear all notifications?')) {
+      this.notifications = [];
+      this.unreadCount = 0;
+      this.saveNotifications();
+      this.renderInbox();
+
+      const badge = this.iconElement.querySelector('.inbox-badge');
+      badge.style.display = 'none';
+    }
+  }
+}
+
+// ============== ENHANCED PUBLIC OPINION BATTLE MINI-GAME ==============
+
+class PublicOpinionBattleGame {
+  constructor(game, opponent, topic, initialData) {
+    this.game = game;
+    this.opponent = opponent;
+    this.topic = topic;
+    this.playerScore = initialData.playerScore || 50;
+    this.opponentScore = initialData.opponentScore || 50;
+    this.startTime = Date.now();
+    this.duration = 120000; // 2 minutes
+    this.maxRounds = 5;
+    this.currentRound = 0;
+    this.rounds = [];
+    this.powerups = {
+      mediaSpin: { used: false, effect: 15, cost: 10 },
+      populistAppeal: { used: false, effect: 20, cost: 15 },
+      factCheck: { used: false, effect: 10, cost: 5 },
+    };
+    this.resultShown = null;
+
+    this.generateRounds();
+    this.render();
+    this.startTimer();
+  }
+
+  generateRounds() {
+    const topics = [
+      {
+        question: `${this.opponent.name} claims your handling of ${this.topic} is inadequate. How do you respond?`,
+        options: [
+          { text: 'Present data and evidence', effect: 12, chaos: 3 },
+          { text: 'Rally public support', effect: 15, chaos: 5 },
+          { text: 'Attack their credibility', effect: 18, chaos: 10 },
+          { text: 'Propose compromise', effect: 8, chaos: 5 },
+        ],
+      },
+      {
+        question: `The media is amplifying ${this.opponent.name}'s criticism. Your move?`,
+        options: [
+          { text: 'Schedule prime-time interview', effect: 14, chaos: 2 },
+          { text: 'Launch tweet offensive', effect: 16, chaos: 8 },
+          { text: 'Leak favorable story', effect: 12, chaos: 6 },
+          { text: 'Stay silent, let it pass', effect: 5, chaos: 2 },
+        ],
+      },
+      {
+        question: `${this.opponent.name} just gained ground with swing voters. Counter?`,
+        options: [
+          { text: 'Promise economic relief', effect: 18, chaos: 4 },
+          { text: 'Announce leadership reshuffle', effect: 15, chaos: 9 },
+          { text: 'Go on the offensive', effect: 15, chaos: 12 },
+          { text: 'Appeal to unity', effect: 10, chaos: 4 },
+        ],
+      },
+      {
+        question: `A scandal from your past resurfaces. ${this.opponent.name} is exploiting it.`,
+        options: [
+          { text: 'Deny and deflect', effect: 8, chaos: 8 },
+          { text: 'Offer public apology', effect: 12, chaos: 3 },
+          { text: 'Threaten legal action', effect: 13, chaos: 10 },
+          { text: 'Make light of it', effect: 12, chaos: 4 },
+        ],
+      },
+      {
+        question: `Final showdown: ${this.opponent.name} challenges you to a public debate.`,
+        options: [
+          { text: 'Accept immediately and prepare', effect: 28, chaos: 6 },
+          { text: 'Set strict conditions', effect: 18, chaos: 2 },
+          { text: 'Avoid and stall', effect: -5, chaos: 3 },
+          { text: 'Accept and attack', effect: 25, chaos: 15 },
+        ],
+      },
+    ];
+
+    this.rounds = topics.slice(0, this.maxRounds);
+  }
+
+  render() {
+    const existing = document.querySelector('.public-opinion-battle');
+    if (existing) existing.remove();
+
+    const battle = document.createElement('div');
+    battle.className = 'public-opinion-battle';
+    this.battleElement = battle;
+
+    this.updateBattleUI();
+
+    const crisisPanel = document.getElementById('crisisPanel');
+    if (crisisPanel) {
+      crisisPanel.insertAdjacentElement('afterend', battle);
+    } else {
+      document.querySelector('.game-container').appendChild(battle);
+    }
+  }
+
+  updateBattleUI() {
+    if (!this.battleElement) return;
+
+    const timeLeft = Math.max(0, Math.ceil((this.duration - (Date.now() - this.startTime)) / 1000));
+    const minutes = Math.floor(timeLeft / 60);
+    const seconds = timeLeft % 60;
+
+    const round = this.rounds[this.currentRound];
+    const isComplete = this.currentRound >= this.maxRounds;
+
+    this.battleElement.innerHTML = `
+      <div class="battle-header">
+        <h4>Public Opinion Battle: ${this.topic}</h4>
+        <div class="battle-timer">${minutes}:${seconds.toString().padStart(2, '0')}</div>
+      </div>
+
+      <div class="battle-progress">
+        ${Array.from({ length: this.maxRounds }).map((_, i) => `
+          <div class="battle-progress-dot ${i < this.currentRound ? 'completed' : (i === this.currentRound ? 'active' : '')}"></div>
+        `).join('')}
+      </div>
+
+      <div class="battle-scores-container">
+        <div class="battle-score-item">
+          <div class="battle-score-label">
+            <span style="color: var(--primary-gold); font-size: 18px;">${Math.round(this.playerScore)}%</span>
+          </div>
+          <div class="battle-score-bar">
+            <div class="battle-score-fill player" style="width: ${this.playerScore}%"></div>
+          </div>
+        </div>
+
+        <div class="battle-score-item">
+          <div class="battle-score-label">
+            <span>${this.opponent.name}</span>
+            <span style="color: inherit; font-size: 18px;">${Math.round(this.opponentScore)}%</span>
+          </div>
+          <div class="battle-score-bar">
+            <div class="battle-score-fill opponent" style="width: ${this.opponentScore}%"></div>
+          </div>
+        </div>
+      </div>
+
+      ${!isComplete ? `
+        <div class="battle-interactive">
+          <div class="battle-question">
+            <strong>Round ${this.currentRound + 1}/${this.maxRounds}</strong><br>
+            ${round.question}
+          </div>
+
+          <div class="battle-options">
+            ${round.options.map((option, i) => `
+              <button class="battle-option-btn" data-index="${i}">
+                ${option.text}
+                <div class="battle-option-effect">
+                  ${option.effect >= 0 ? '+' : ''}${option.effect}${option.chaos ? ` · chaos: ${option.chaos}` : ''}
+                </div>
+              </button>
+            `).join('')}
+          </div>
+        </div>
+      ` : ''}
+
+      <div class="battle-powerups">
+        ${Object.entries(this.powerups).map(([key, powerup]) => `
+          <div class="battle-powerup ${powerup.used ? 'used' : ''}" data-powerup="${key}">
+            <span>${this.getPowerupIcon(key)}</span>
+            <span style="margin-left: auto;">${powerup.used ? 'USED' : `-${powerup.cost} energy`}</span>
+          </div>
+        `).join('')}
+      </div>
+    `;
+
+    // Add event listeners
+    if (!isComplete) {
+      this.battleElement.querySelectorAll('.battle-option-btn').forEach(btn => {
+        btn.onclick = () => this.handleChoice(parseInt(btn.dataset.index));
+      });
+      this.battleElement.querySelectorAll('.battle-powerup').forEach(btn => {
+        btn.onclick = () => this.usePowerup(btn.dataset.powerup);
+      });
+    }
+  }
+
+  handleChoice(index) {
+    const round = this.rounds[this.currentRound];
+    const option = round.options[index];
+
+    // Calculate outcomes (weighted by their aggression)
+    const opponentResponse = Math.random() * (this.opponent.aggression / 10);
+
+    this.playerScore = Math.min(100, Math.max(0, this.playerScore + option.effect - opponentResponse));
+    this.opponentScore = Math.max(0, Math.min(100, this.opponentScore + opponentResponse - (option.effect / 2)));
+
+    // Store round result
+    this.rounds[this.currentRound].playerEffect = option.effect;
+
+    // Move to next round
+    if (this.currentRound >= this.maxRounds || (Date.now() - this.startTime >= this.duration)) {
+      this.endBattle();
+    } else {
+      this.currentRound++;
+      this.updateBattleUI();
+    }
+  }
+
+  usePowerup(powerupKey) {
+    const powerup = this.powerups[powerupKey];
+    if (!powerup || (this.game.energy < powerup.cost)) {
+      this.game.showNotification('Cannot use power-up', 'warning');
+      return;
+    }
+
+    powerup.used = true;
+    this.playerScore = Math.min(100, this.playerScore + powerup.effect);
+    this.opponentScore = Math.max(0, this.opponentScore - (powerup.effect / 2));
+
+    this.game.state.applyEffects({
+      power: '+ opinion-battle power-up',
+    });
+
+    this.game.inbox.addNotification(`Used ${this.getPowerupName(powerupKey)}!`, 'success');
+    this.updateBattleUI();
+  }
+
+  getPowerupIcon(key) {
+    const icons = { mediaSpin: '🌀', populistAppeal: '📣', factCheck: '🧾' };
+    return icons[key] || '✨';
+  }
+
+  getPowerupName(key) {
+    const names = { mediaSpin: 'Media Spin', populistAppeal: 'Populist Appeal', factCheck: 'Fact Check' };
+    return names[key] || key;
+  }
+
+  renderResult() {
+    const won = this.playerScore > this.opponentScore;
+    const margin = Math.abs(this.playerScore - this.opponentScore);
+
+    return `
+      <div class="battle-result ${won ? 'victory' : 'defeat'}">
+        <h3>${won ? '🏆 VICTORY!' : '❌ DEFEAT'}</h3>
+        <p style="font-size: 16px; margin: 18px 0;">
+          ${won
+            ? `${this.opponent.name} by ${Math.round(margin)} points!`
+            : `${this.opponent.name} defeated you by ${Math.round(margin)} points.`}
+        </p>
+
+        <div class="battle-result-effects">
+          <div class="battle-result-effect">Public Opinion: ${Math.round(margin * 0.5)}%</div>
+          <div class="battle-result-effect">Public Support: ${Math.round(margin * 0.3)}%</div>
+          <div class="battle-result-effect">Chaos: ${Math.round(margin * 0.2)}%</div>
+        </div>
+
+        <button class="close-modal" onclick="this.closest('.public-opinion-battle').remove()" style="margin-top: 20px;">Close</button>
+      </div>
+    `;
+  }
+
+  endBattle() {
+    const won = this.playerScore > this.opponentScore;
+    const margin = Math.abs(this.playerScore - this.opponentScore);
+
+    if (won) {
+      this.game.state.applyEffects({ power: `+ public: margin x 0.5`, scoreDelta: margin * 1.5, chaosDelta: 5 });
+      this.game.inbox.addNotification(
+        `🏆 Victory in public opinion battle against ${this.opponent.name}! Public support increased by ${Math.round(margin * 0.5)}%.`,
+        'success',
+        { opponent: this.opponent.name, topic: this.topic, margin: Math.round(margin) },
+      );
+    } else {
+      this.game.state.applyEffects({ power: `- public: margin x 0.5`, scoreDelta: -margin * 0.5, chaosDelta: 5 });
+      this.game.inbox.addNotification(
+        `Lost this topic's opinion battle to ${this.opponent.name}. Public support decreased.`,
+        'warning',
+        { opponent: this.opponent.name, topic: this.topic, margin: Math.round(margin) },
+      );
+    }
+
+    this.updateBattleUI();
+  }
+
+  startTimer() {
+    this.timerInterval = setInterval(() => {
+      const timeLeft = Math.max(0, this.duration - (Date.now() - this.startTime));
+      if (timeLeft <= 0) {
+        clearInterval(this.timerInterval);
+        if (this.currentRound < this.maxRounds) this.endBattle();
+        else this.updateBattleUI();
+      }
+    }, 1000);
+  }
+}
+
 class PresidentGame {
     constructor() {
         // POWER CENTERS - The Core System
@@ -190,6 +746,9 @@ class PresidentGame {
             powerChanges: [],
             crises: []
         };
+
+        this.inbox = new NotificationInbox(this);
+        this.activeBattles = [];
 
         this.notifications = [];
         this.maxVisibleNotifications = 5;
@@ -1944,20 +2503,23 @@ class PresidentGame {
 
     // PUBLIC OPINION BATTLES
     createPublicOpinionBattle(opponent, response, analysis) {
-        const battle = {
-            id: Date.now(),
-            opponent: opponent,
-            topic: this.extractTopic(response.content),
-            playerScore: 50,
-            opponentScore: 50,
-            startTime: Date.now(),
-            duration: 300000, // 5 minutes
-            viralMultiplier: analysis.viralPotential / 10,
-            controversyLevel: analysis.controversyLevel
-        };
+        const battle = new PublicOpinionBattleGame(
+            this,
+            opponent,
+            this.extractTopic(response.content),
+            {
+                playerScore: 50,
+                opponentScore: 50,
+            }
+        );
 
-        this.publicOpinionBattles.push(battle);
-        this.showPublicOpinionBattle(battle);
+        this.activeBattles.push(battle);
+
+        this.inbox.addNotification(
+            `🗞️ New public opinion battle started with ${opponent.name} over ${battle.topic}!`,
+            'info',
+            { opponent: opponent.name, topic: battle.topic }
+        );
     }
 
     // EXTRACT TOPIC FROM TWEET
@@ -3676,34 +4238,32 @@ class PresidentGame {
         }
     }
 
-    showNotification(message, type = 'info', duration = 4000, dismissible = true) {
+    showNotification(message, type = 'info', duration = 10000, dismissible = true, metadata = {}) {
         const id = this.notificationId++;
+
+        // Add to inbox
+        this.inbox.addNotification(message, type, metadata);
 
         const notification = {
             id,
             message: this.sanitizeText(message),
             type,
             timestamp: Date.now(),
-            duration
+            duration,
+            metadata,
         };
 
         this.notifications.push(notification);
 
         const notifEl = document.createElement('div');
-        notifEl.className = `notification ${type}`;
-        notifEl.id = `notification-${id}`;
+        notifEl.className = 'notification';
         notifEl.dataset.notificationId = id;
 
-        const icons = {
-            info: 'ℹ️',
-            success: '✅',
-            warning: '⚠️',
-            error: '❌'
-        };
+        const icons = { info: 'ℹ️', success: '✅', warning: '⚠️', error: '❌' };
 
         const icon = document.createElement('div');
         icon.className = 'notification-icon';
-        icon.textContent = icons[type] || 'ℹ️';
+        icon.textContent = icons[type] || '';
 
         const content = document.createElement('div');
         content.className = 'notification-content';
@@ -3712,13 +4272,20 @@ class PresidentGame {
         notifEl.appendChild(icon);
         notifEl.appendChild(content);
 
+        // Click to expand
+        notifEl.onclick = () => {
+            this.inbox.openNotificationDetail(this.inbox.notifications.find(n => n.message === message)?.id);
+        };
+
         if (dismissible) {
             const closeBtn = document.createElement('button');
             closeBtn.className = 'notification-close';
             closeBtn.type = 'button';
-            closeBtn.setAttribute('aria-label', 'Close notification');
-            closeBtn.innerHTML = '×';
-            closeBtn.onclick = () => this.dismissNotification(id);
+            closeBtn.ariaLabel = 'Close notification';
+            closeBtn.onclick = (e) => {
+                e.stopPropagation();
+                this.dismissNotification(id);
+            };
             notifEl.appendChild(closeBtn);
         }
 
@@ -3730,7 +4297,6 @@ class PresidentGame {
         }
 
         this.enforceNotificationLimit();
-        return id;
     }
 
     dismissNotification(id) {

--- a/assets/styles.css
+++ b/assets/styles.css
@@ -1391,3 +1391,519 @@ body {
         gap: 10px;
     }
 }
+
+/* ========================= NOTIFICATION INBOX ========================= */
+.notification-inbox-icon {
+    position: fixed;
+    top: 24px;
+    right: 24px;
+    width: 56px;
+    height: 56px;
+    border-radius: 18px;
+    background: rgba(13, 18, 32, 0.9);
+    border: 1px solid var(--glass-border);
+    backdrop-filter: blur(12px);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    cursor: pointer;
+    box-shadow: var(--shadow-lg);
+    transition: transform 0.25s ease, box-shadow 0.25s ease;
+    z-index: 1400;
+}
+
+.notification-inbox-icon:hover {
+    transform: translateY(-3px) scale(1.05);
+    box-shadow: 0 20px 45px rgba(0, 0, 0, 0.4);
+}
+
+.notification-inbox-icon .inbox-icon {
+    font-size: 28px;
+}
+
+.notification-inbox-icon .inbox-badge {
+    position: absolute;
+    top: -6px;
+    right: -6px;
+    width: 24px;
+    height: 24px;
+    border-radius: 12px;
+    background: var(--primary-red);
+    color: #fff;
+    font-size: 13px;
+    font-weight: 700;
+    display: none;
+    align-items: center;
+    justify-content: center;
+    box-shadow: 0 4px 12px rgba(220, 20, 60, 0.6);
+}
+
+.notification-inbox-panel {
+    position: fixed;
+    top: 0;
+    right: -420px;
+    width: 360px;
+    height: 100vh;
+    background: rgba(8, 12, 24, 0.95);
+    border-left: 1px solid var(--glass-border);
+    box-shadow: -20px 0 50px rgba(0, 0, 0, 0.45);
+    backdrop-filter: blur(18px);
+    display: flex;
+    flex-direction: column;
+    padding: 28px 24px;
+    transition: right 0.35s ease;
+    z-index: 1350;
+}
+
+.notification-inbox-panel.open {
+    right: 0;
+}
+
+.inbox-header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    margin-bottom: 22px;
+}
+
+.inbox-header h3 {
+    font-size: 20px;
+    font-weight: 700;
+    letter-spacing: 0.04em;
+}
+
+.inbox-close-btn {
+    background: transparent;
+    color: #fff;
+    border: none;
+    font-size: 28px;
+    cursor: pointer;
+    padding: 0 6px;
+    line-height: 1;
+    transition: transform 0.2s ease, color 0.2s ease;
+}
+
+.inbox-close-btn:hover {
+    transform: scale(1.1);
+    color: var(--primary-gold);
+}
+
+.inbox-filters {
+    display: grid;
+    grid-template-columns: repeat(5, 1fr);
+    gap: 8px;
+    margin-bottom: 18px;
+}
+
+.inbox-filter-btn {
+    border: 1px solid rgba(255, 255, 255, 0.1);
+    border-radius: 12px;
+    padding: 8px 10px;
+    font-size: 12px;
+    letter-spacing: 0.05em;
+    background: rgba(255, 255, 255, 0.04);
+    color: #dfe5ff;
+    text-transform: uppercase;
+    cursor: pointer;
+    transition: background 0.2s ease, border-color 0.2s ease, color 0.2s ease;
+}
+
+.inbox-filter-btn:hover {
+    background: rgba(255, 255, 255, 0.12);
+}
+
+.inbox-filter-btn.active {
+    background: linear-gradient(135deg, rgba(255, 215, 0, 0.18), rgba(255, 215, 0, 0.4));
+    border-color: rgba(255, 215, 0, 0.5);
+    color: var(--primary-gold);
+}
+
+#inboxContent {
+    flex: 1;
+    overflow-y: auto;
+    padding-right: 6px;
+}
+
+.inbox-notification {
+    background: rgba(255, 255, 255, 0.04);
+    border-radius: 16px;
+    padding: 16px;
+    margin-bottom: 14px;
+    border: 1px solid rgba(255, 255, 255, 0.05);
+    box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.03);
+    cursor: pointer;
+    transition: transform 0.2s ease, box-shadow 0.2s ease, border-color 0.2s ease;
+}
+
+.inbox-notification.unread {
+    background: rgba(255, 255, 255, 0.08);
+    border-color: rgba(255, 215, 0, 0.35);
+    box-shadow: 0 16px 32px rgba(0, 0, 0, 0.35);
+}
+
+.inbox-notification.info {
+    border-left: 3px solid var(--primary-blue);
+}
+
+.inbox-notification.success {
+    border-left: 3px solid #32cd32;
+}
+
+.inbox-notification.warning {
+    border-left: 3px solid #ffa500;
+}
+
+.inbox-notification.error {
+    border-left: 3px solid var(--primary-red);
+}
+
+.inbox-notification:hover {
+    transform: translateY(-3px);
+    box-shadow: 0 18px 38px rgba(0, 0, 0, 0.4);
+}
+
+.inbox-notification-header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    font-size: 12px;
+    letter-spacing: 0.05em;
+    opacity: 0.75;
+    margin-bottom: 8px;
+}
+
+.inbox-notification-time {
+    font-size: 11px;
+    color: rgba(255, 255, 255, 0.6);
+}
+
+.inbox-notification-preview {
+    font-size: 14px;
+    line-height: 1.4;
+    color: #f5f7ff;
+}
+
+.notification-detail-modal {
+    position: fixed;
+    top: 50%;
+    left: 50%;
+    transform: translate(-50%, -50%);
+    width: min(480px, 90vw);
+    background: rgba(10, 14, 26, 0.94);
+    border-radius: 20px;
+    border: 1px solid rgba(255, 255, 255, 0.12);
+    box-shadow: 0 30px 80px rgba(0, 0, 0, 0.55);
+    padding: 28px;
+    z-index: 1500;
+    backdrop-filter: blur(20px);
+}
+
+.notification-detail-header {
+    display: flex;
+    align-items: center;
+    gap: 16px;
+    margin-bottom: 18px;
+}
+
+.notification-detail-icon {
+    font-size: 32px;
+}
+
+.notification-detail-title h3 {
+    font-size: 20px;
+    letter-spacing: 0.05em;
+}
+
+.notification-detail-title .time {
+    font-size: 12px;
+    color: rgba(255, 255, 255, 0.6);
+    margin-top: 2px;
+}
+
+.notification-detail-content {
+    font-size: 15px;
+    line-height: 1.6;
+    color: #f6f7ff;
+}
+
+.notification-detail-actions {
+    display: flex;
+    gap: 12px;
+    margin-top: 24px;
+}
+
+.notification-detail-actions .close-modal {
+    background: linear-gradient(135deg, rgba(255, 215, 0, 0.3), rgba(255, 215, 0, 0.6));
+    border: none;
+    border-radius: 12px;
+    padding: 12px 16px;
+    color: #1a1f33;
+    font-weight: 700;
+    cursor: pointer;
+    letter-spacing: 0.05em;
+    transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.notification-detail-actions .close-modal:hover {
+    transform: translateY(-2px);
+    box-shadow: 0 16px 30px rgba(255, 215, 0, 0.35);
+}
+
+/* ===================== PUBLIC OPINION BATTLE ===================== */
+.public-opinion-battle {
+    margin: 24px auto;
+    width: min(720px, 95%);
+    background: linear-gradient(135deg, rgba(88, 63, 191, 0.65), rgba(20, 14, 52, 0.95));
+    border-radius: 28px;
+    border: 1px solid rgba(150, 120, 255, 0.35);
+    box-shadow: 0 28px 60px rgba(56, 38, 120, 0.45);
+    padding: 28px;
+    color: #f4f3ff;
+    position: relative;
+    overflow: hidden;
+}
+
+.public-opinion-battle::before {
+    content: '';
+    position: absolute;
+    inset: 0;
+    background: radial-gradient(circle at top right, rgba(255, 215, 0, 0.18), transparent 55%);
+    opacity: 0.8;
+    pointer-events: none;
+}
+
+.battle-header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    margin-bottom: 18px;
+    position: relative;
+    z-index: 1;
+}
+
+.battle-header h4 {
+    font-size: 22px;
+    letter-spacing: 0.04em;
+    text-transform: uppercase;
+}
+
+.battle-timer {
+    font-size: 20px;
+    font-weight: 700;
+    color: var(--primary-gold);
+    background: rgba(0, 0, 0, 0.2);
+    border-radius: 14px;
+    padding: 8px 16px;
+    box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.08);
+}
+
+.battle-progress {
+    display: flex;
+    gap: 8px;
+    margin-bottom: 22px;
+    position: relative;
+    z-index: 1;
+}
+
+.battle-progress-dot {
+    width: 14px;
+    height: 14px;
+    border-radius: 50%;
+    background: rgba(255, 255, 255, 0.2);
+    box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.1);
+    transition: background 0.2s ease, transform 0.2s ease;
+}
+
+.battle-progress-dot.active {
+    background: var(--primary-gold);
+    transform: scale(1.15);
+}
+
+.battle-progress-dot.completed {
+    background: #7cffc4;
+}
+
+.battle-scores-container {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    gap: 16px;
+    margin-bottom: 24px;
+    position: relative;
+    z-index: 1;
+}
+
+.battle-score-item {
+    background: rgba(0, 0, 0, 0.25);
+    padding: 16px;
+    border-radius: 18px;
+    border: 1px solid rgba(255, 255, 255, 0.08);
+    box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.05);
+}
+
+.battle-score-label {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    font-size: 14px;
+    margin-bottom: 10px;
+}
+
+.battle-score-bar {
+    height: 10px;
+    border-radius: 6px;
+    background: rgba(255, 255, 255, 0.12);
+    overflow: hidden;
+}
+
+.battle-score-fill {
+    height: 100%;
+    border-radius: 6px;
+    transition: width 0.45s ease;
+}
+
+.battle-score-fill.player {
+    background: linear-gradient(135deg, var(--primary-gold), #ff9f43);
+}
+
+.battle-score-fill.opponent {
+    background: linear-gradient(135deg, #7d8bff, #3a49d6);
+}
+
+.battle-interactive {
+    background: rgba(12, 16, 32, 0.55);
+    border-radius: 22px;
+    border: 1px solid rgba(255, 255, 255, 0.08);
+    padding: 22px;
+    margin-bottom: 20px;
+    position: relative;
+    z-index: 1;
+}
+
+.battle-question {
+    font-size: 16px;
+    line-height: 1.5;
+    margin-bottom: 16px;
+}
+
+.battle-options {
+    display: grid;
+    gap: 12px;
+}
+
+.battle-option-btn {
+    border: 1px solid rgba(255, 255, 255, 0.12);
+    border-radius: 16px;
+    padding: 14px 16px;
+    background: rgba(255, 255, 255, 0.05);
+    color: #f8f9ff;
+    text-align: left;
+    font-size: 15px;
+    cursor: pointer;
+    transition: transform 0.2s ease, box-shadow 0.2s ease, border-color 0.2s ease;
+}
+
+.battle-option-btn:hover {
+    transform: translateY(-3px);
+    border-color: rgba(255, 215, 0, 0.5);
+    box-shadow: 0 16px 32px rgba(0, 0, 0, 0.35);
+}
+
+.battle-option-effect {
+    margin-top: 8px;
+    font-size: 12px;
+    opacity: 0.75;
+    letter-spacing: 0.05em;
+}
+
+.battle-powerups {
+    display: flex;
+    gap: 12px;
+    position: relative;
+    z-index: 1;
+}
+
+.battle-powerup {
+    flex: 1;
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    background: rgba(0, 0, 0, 0.28);
+    border-radius: 14px;
+    padding: 12px 16px;
+    border: 1px solid rgba(255, 255, 255, 0.1);
+    cursor: pointer;
+    transition: transform 0.2s ease, border-color 0.2s ease, box-shadow 0.2s ease;
+}
+
+.battle-powerup:hover {
+    transform: translateY(-3px);
+    border-color: rgba(255, 215, 0, 0.45);
+    box-shadow: 0 18px 34px rgba(0, 0, 0, 0.4);
+}
+
+.battle-powerup.used {
+    opacity: 0.45;
+    cursor: default;
+    filter: grayscale(0.4);
+}
+
+.battle-result {
+    text-align: center;
+    background: rgba(0, 0, 0, 0.25);
+    border-radius: 24px;
+    padding: 28px;
+    border: 1px solid rgba(255, 255, 255, 0.1);
+    margin-top: 20px;
+    position: relative;
+    z-index: 1;
+}
+
+.battle-result.victory {
+    box-shadow: 0 22px 48px rgba(255, 215, 0, 0.25);
+}
+
+.battle-result.defeat {
+    box-shadow: 0 22px 48px rgba(220, 20, 60, 0.25);
+}
+
+.battle-result-effects {
+    display: grid;
+    gap: 12px;
+    margin-top: 18px;
+}
+
+.battle-result-effect {
+    background: rgba(255, 255, 255, 0.06);
+    border-radius: 14px;
+    padding: 10px;
+    font-size: 14px;
+}
+
+@media (max-width: 768px) {
+    .notification-inbox-icon {
+        top: 16px;
+        right: 16px;
+        width: 52px;
+        height: 52px;
+    }
+
+    .notification-inbox-panel {
+        width: 100%;
+    }
+
+    .inbox-filters {
+        grid-template-columns: repeat(3, 1fr);
+    }
+
+    .public-opinion-battle {
+        padding: 22px;
+    }
+
+    .battle-scores-container {
+        grid-template-columns: 1fr;
+    }
+
+    .battle-powerups {
+        flex-direction: column;
+    }
+}


### PR DESCRIPTION
## Summary
- add the NotificationInbox system to persist and display notifications with filtering and detail views
- introduce the PublicOpinionBattleGame class for the new five-round opinion battle experience and hook it into the game
- initialize the inbox and active battle tracking in the main game, upgrade notification handling, add supporting styles, and document rollout steps

## Testing
- not run (not available)

------
https://chatgpt.com/codex/tasks/task_e_68e20099df7c832a837778d8fc536c6a